### PR TITLE
Support non-default installation paths

### DIFF
--- a/emoji-copy@felipeftn/extension.js
+++ b/emoji-copy@felipeftn/extension.js
@@ -44,7 +44,7 @@ export default class EmojiCopy extends Extension {
     this._permanentItems = 0;
 
     this.sqlite = new SQLite();
-    await this.sqlite.initializeDB();
+    await this.sqlite.initializeDB(this.path);
 
     this.super_btn = new PanelMenu.Button(0.0, _("Emoji Copy"), false);
     let box = new St.BoxLayout();

--- a/emoji-copy@felipeftn/handlers/sql.js
+++ b/emoji-copy@felipeftn/handlers/sql.js
@@ -7,14 +7,9 @@ import GLib from "gi://GLib";
 
 import { initSqlJs } from "../libs/sql/sql.js";
 
-async function ReadDB() {
+async function ReadDB(extensionPath) {
   const p = GLib.build_filenamev([
-    GLib.get_home_dir(),
-    ".local",
-    "share",
-    "gnome-shell",
-    "extensions",
-    "emoji-copy@felipeftn",
+    extensionPath,
     "data",
     "emojis.db",
   ]);
@@ -28,9 +23,9 @@ export class SQLite {
     this.db = null;
   }
 
-  async initializeDB() {
+  async initializeDB(extensionPath) {
     try {
-      const [SQL, db] = await Promise.all([initSqlJs(), ReadDB()]);
+      const [SQL, db] = await Promise.all([initSqlJs(), ReadDB(extensionPath)]);
       this.db = new SQL.Database(new Uint8Array(db));
     } catch (error) {
       console.error("Error initializing database:", error);


### PR DESCRIPTION
This PR adds support for non-default extension installation paths (e.g. NixOS installs extensions to `/nix/store`).