### PR TITLE
feat: support gnome 47

### DIFF
--- a/emoji-copy@felipeftn/metadata.json
+++ b/emoji-copy@felipeftn/metadata.json
@@ -2,7 +2,7 @@
   "uuid": "emoji-copy@felipeftn",
   "name": "Emoji Copy",
   "description": "Emoji copy is a versatile extension designed to simplify emoji selection and clipboard management.\n\nIt is a fork of Emoji Selector.",
-  "shell-version": ["45", "46"],
+  "shell-version": ["45", "46", "47"],
   "url": "https://github.com/felipeftn/emoji-copy",
   "settings-schema": "org.gnome.shell.extensions.emoji-copy",
   "gettext-domain": "emoji-copy",


### PR DESCRIPTION
I tested this on [Gnome OS Nightly](https://os.gnome.org/), and went though the [gjs 46 - 47](https://gjs.guide/extensions/upgrading/gnome-shell-47.html#port-extensions-to-gnome-shell-47) extension guide and everything seems to work!

We could make the [fillPreferencesWindow](https://github.com/FelipeFTN/Emoji-Copy/blob/fc770d761c971886d656e09f0083e9cdadcd18c2/emoji-copy%40felipeftn/prefs.js#L8) async looking at the guide, but it doesn't look like there is anything that would benefit from it at the moment