### PR TITLE
🔎 skin tone search should only affect relevant emoji

### DIFF
--- a/emoji-copy@felipeftn/handlers/sql.js
+++ b/emoji-copy@felipeftn/handlers/sql.js
@@ -59,7 +59,7 @@ export class SQLite {
     if (skin_tone != 0) {
       const skin_tone_str = this.get_skin_tone(skin_tone);
       return this.query(`
-        SELECT * FROM emojis WHERE (${sql_string}) AND skin_tone LIKE '%${skin_tone_str}%' ORDER BY clicked_times DESC;
+        SELECT * FROM emojis WHERE (${sql_string}) AND (skin_tone = '' OR skin_tone LIKE '%${skin_tone_str}%') ORDER BY clicked_times DESC;
       `);
     }
 


### PR DESCRIPTION
This changes the SQL query used for search so that skin tone filtering only applies to emoji that actually have skin tone variants.

This means the search results also include other emoji, e.g. ‘lemon’ will actually find 🍋, as intended.

Fixes #62
Fixes https://github.com/FelipeFTN/Emoji-Copy/issues/62