### PR TITLE
Add GNOME 49 compatibility

### DIFF
--- a/emoji-copy@felipeftn/emojiButton.js
+++ b/emoji-copy@felipeftn/emojiButton.js
@@ -49,7 +49,7 @@ export class EmojiButton {
       can_focus: true,
       label: this.baseCharacter,
     });
-    
+
     // Copy the emoji to the clipboard with adequate tags and behavior
     this.super_btn.connect("button-press-event", this.onButtonPress.bind(this));
     this.super_btn.connect("key-press-event", this.onKeyPress.bind(this));
@@ -103,9 +103,9 @@ export class EmojiButton {
     ) {
       let emojiToCopy = this.getTaggedEmoji();
       this.emojiCopy.sqlite.increment_selection(emojiToCopy);
-      let [_x, _y, mods] = global.get_pointer();
-      let majPressed = (mods & Clutter.ModifierType.SHIFT_MASK) != 0;
-      let ctrlPressed = (mods & Clutter.ModifierType.CONTROL_MASK) != 0;
+      const state = typeof e.get_state === 'function' ? e.get_state() : 0;
+      const majPressed = (state & Clutter.ModifierType.SHIFT_MASK) !== 0;
+      const ctrlPressed = (state & Clutter.ModifierType.CONTROL_MASK) !== 0;
       if (majPressed) {
         return this.addToClipboardAndStay(emojiToCopy);
       } else if (ctrlPressed) {

--- a/emoji-copy@felipeftn/emojiCategory.js
+++ b/emoji-copy@felipeftn/emojiCategory.js
@@ -38,8 +38,8 @@ export class EmojiCategory {
       EMOJIS_CATEGORIES[this.id],
     );
 
-    this.super_item.actor.visible = false;
-    this.super_item.actor.reactive = false;
+    this.super_item.visible = false;
+    this.super_item.reactive = false;
     this.super_item._triangleBin.visible = false;
 
     // These options bar widgets have the same type for all categories to
@@ -52,7 +52,7 @@ export class EmojiCategory {
 
     // Smileys & body Peoples Activities
     if ((this.id == 0) || (this.id == 1) || (this.id == 5)) {
-      this.skinTonesBar.addBar(this.super_item.actor);
+      this.skinTonesBar.addBar(this.super_item);
     }
 
     this.categoryButton = new St.Button({
@@ -81,7 +81,7 @@ export class EmojiCategory {
       reactive: false,
       can_focus: false,
     });
-    line.actor.add_child(
+    line.add_child(
       new St.Label({
         text: error_message,
       }),
@@ -133,9 +133,9 @@ export class EmojiCategory {
           reactive: false,
           can_focus: false,
         });
-        ln.actor.track_hover = false;
+        ln.track_hover = false;
         container = new St.BoxLayout();
-        ln.actor.add_child(container);
+        ln.add_child(container);
         this.super_item.menu.addMenuItem(ln);
       }
       this.emojiButtons[i].build(this);
@@ -145,7 +145,7 @@ export class EmojiCategory {
   }
 
   _toggle() {
-    if (this.super_item._getOpenState()) {
+    if (this.super_item.menu && this.super_item.menu.isOpen) {
       this.emojiCopy.clearCategories();
     } else {
       this._openCategory();
@@ -164,7 +164,7 @@ export class EmojiCategory {
     this.skinTonesBar.update();
 
     this.categoryButton.set_checked(true);
-    this.super_item.actor.visible = true;
+    this.super_item.visible = true;
     this.super_item.setSubmenuShown(true); // This is causing the Lag!
     this.emojiCopy._onSearchTextChanged();
   }

--- a/emoji-copy@felipeftn/emojiSearchItem.js
+++ b/emoji-copy@felipeftn/emojiSearchItem.js
@@ -31,7 +31,7 @@ export class EmojiSearchItem {
       this._onSearchTextChanged.bind(this),
     );
 
-    this.super_item.actor.add_child(this.searchEntry);
+    this.super_item.add_child(this.searchEntry);
 
     // initializing the "recently used" buttons
     this.recentlyUsedItem = this._recentlyUsedInit();
@@ -140,7 +140,7 @@ export class EmojiSearchItem {
       can_focus: false,
     });
     let container = new St.BoxLayout();
-    recentlyUsed.actor.add_child(container);
+    recentlyUsed.add_child(container);
     this._recents = [];
 
     for (let i = 0; i < this._nbColumns; i++) {

--- a/emoji-copy@felipeftn/extension.js
+++ b/emoji-copy@felipeftn/extension.js
@@ -197,12 +197,12 @@ export default class EmojiCopy extends Extension {
     if (this.position == "top") {
       for (let i = this._permanentItems; i < items.length; i++) {
         items[i].setSubmenuShown(false);
-        items[i].actor.visible = false;
+        items[i].visible = false;
       }
     } else {
       for (let i = 0; i < (items.length - this._permanentItems); i++) {
         items[i].setSubmenuShown(false);
-        items[i].actor.visible = false;
+        items[i].visible = false;
       }
     }
 
@@ -264,7 +264,7 @@ export default class EmojiCopy extends Extension {
     });
     this.categoryButton = [];
     for (let i = 0; i < this.emojiCategories.length; i++) {
-      this._buttonMenuItem.actor.add_child(this.emojiCategories[i].getButton());
+      this._buttonMenuItem.add_child(this.emojiCategories[i].getButton());
     }
   }
 

--- a/emoji-copy@felipeftn/metadata.json
+++ b/emoji-copy@felipeftn/metadata.json
@@ -2,9 +2,9 @@
   "uuid": "emoji-copy@felipeftn",
   "name": "Emoji Copy",
   "description": "Emoji copy is a versatile extension designed to simplify emoji selection and clipboard management.\n\nIt is a fork of Emoji Selector.",
-  "shell-version": ["45", "46", "47", "48"],
+  "shell-version": ["45", "46", "47", "48", "49", "49"],
   "url": "https://github.com/felipeftn/emoji-copy",
   "settings-schema": "org.gnome.shell.extensions.emoji-copy",
   "gettext-domain": "emoji-copy",
-  "version": 28
+  "version": 30
 }


### PR DESCRIPTION
Here’s the rationale:
* PopupMenu APIs: stopped using deprecated .actor to add children and toggle visibility; used the direct APIs instead (e.g., item.add_child, item.visible).
* Open-state check: replaced getOpenState() with menu.isOpen to align with newer GNOME Shell.
* Key modifiers: replaced global.get_pointer() with event.get_state() to detect Shift/Ctrl reliably in newer releases.
* Kept functionality unchanged; just modernized calls to avoid runtime errors on GNOME 49.