### PR TITLE
fix: paste correctly in terminal.

### DIFF
--- a/emoji-copy@felipeftn/emojiButton.js
+++ b/emoji-copy@felipeftn/emojiButton.js
@@ -3,6 +3,7 @@ import Clutter from "gi://Clutter";
 import GLib from "gi://GLib";
 
 const CLIPBOARD_TYPE = St.ClipboardType.CLIPBOARD;
+const PRIMARY_CLIPBOARD_TYPE = St.ClipboardType.PRIMARY; // For pastes into terminal emulators.
 
 const VirtualKeyboard = (() => {
   let VirtualKeyboard;
@@ -147,6 +148,10 @@ export class EmojiButton {
       CLIPBOARD_TYPE,
       emojiToCopy,
     );
+    this.clipboard.set_text(
+      PRIMARY_CLIPBOARD_TYPE,
+      emojiToCopy,
+    );
     this.emojiCopy.get_super_btn().menu.close();
 
     if (this._settings.get_boolean("paste-on-select")) {
@@ -161,6 +166,10 @@ export class EmojiButton {
       CLIPBOARD_TYPE,
       emojiToCopy,
     );
+    this.clipboard.set_text(
+      PRIMARY_CLIPBOARD_TYPE,
+      emojiToCopy,
+    );
 
     return Clutter.EVENT_STOP;
   }
@@ -169,6 +178,10 @@ export class EmojiButton {
     this.clipboard.get_text(CLIPBOARD_TYPE, (_, text) => {
       this.clipboard.set_text(
         CLIPBOARD_TYPE,
+        text + emojiToCopy,
+      );
+      this.clipboard.set_text(
+        PRIMARY_CLIPBOARD_TYPE,
         text + emojiToCopy,
       );
     });

--- a/emoji-copy@felipeftn/emojiButton.js
+++ b/emoji-copy@felipeftn/emojiButton.js
@@ -233,25 +233,28 @@ export class EmojiButton {
       GLib.PRIORITY_DEFAULT,
       1,
       () => {
+        const KEY_Shift_L = 42;
+        const KEY_Insert = 110;
+
         const eventTime = Clutter.get_current_event_time() * 1000;
-        VirtualKeyboard().notify_keyval(
+        VirtualKeyboard().notify_key(
           eventTime,
-          Clutter.KEY_Shift_L,
+          KEY_Shift_L,
           Clutter.KeyState.PRESSED,
         );
-        VirtualKeyboard().notify_keyval(
+        VirtualKeyboard().notify_key(
           eventTime,
-          Clutter.KEY_Insert,
+          KEY_Insert,
           Clutter.KeyState.PRESSED,
         );
-        VirtualKeyboard().notify_keyval(
+        VirtualKeyboard().notify_key(
           eventTime,
-          Clutter.KEY_Insert,
+          KEY_Insert,
           Clutter.KeyState.RELEASED,
         );
-        VirtualKeyboard().notify_keyval(
+        VirtualKeyboard().notify_key(
           eventTime,
-          Clutter.KEY_Shift_L,
+          KEY_Shift_L,
           Clutter.KeyState.RELEASED,
         );
 


### PR DESCRIPTION
Closes #104
Closes #105 

> Pretty strange behavior, it might have something to do with how terminals manage clipboard pasting.

@FelipeFTN It looks like you are right on this one. Terminal emulators use a [different clipboard selection](https://unix.stackexchange.com/a/139193).

I've set all copy actions to place the chosen emoji in both `St.ClipboardType.CLIPBOARD` and `St.ClipboardType.PRIMARY`.

Also switched to key codes for the paste hack to make it work for more keyboard layouts like neo2. Idea taken from [this repo](https://github.com/SUPERCILEX/gnome-clipboard-history/blob/c274be6bd2f5fdafe5832bc87607625811cdfcee/extension.js#L625)