### PR TITLE
fix: prevent cumulative layout shift due to variable label width.

### DIFF
--- a/emoji-copy@felipeftn/emojiButton.js
+++ b/emoji-copy@felipeftn/emojiButton.js
@@ -62,13 +62,11 @@ export class EmojiButton {
     // name of the emoji he's copying.
     this.super_btn.connect("notify::hover", (a, _) => {
       if (a.hover) {
-        category.super_item.label.text = `${
+        category.super_item.label.text =
           this.keywords
             .replaceAll("HAS_TONE", "")
             .replaceAll("HAS_GENDER", "")
-            .replaceAll("OK", "")
-            .substring(0, 35)
-        }...`;
+            .replaceAll("OK", "");
       } else {
         category.super_item.label.text = category.categoryName;
       }

--- a/emoji-copy@felipeftn/emojiCategory.js
+++ b/emoji-copy@felipeftn/emojiCategory.js
@@ -42,6 +42,10 @@ export class EmojiCategory {
     this.super_item.reactive = false;
     this.super_item._triangleBin.visible = false;
 
+    const emoji_size = this._settings.get_int("emojisize");
+    const nbcols = this._nbColumns;
+    this.super_item.label.set_style(`width: ${emoji_size * Math.max(1, nbcols - 3) }px;`);
+
     // These options bar widgets have the same type for all categories to
     // simplify the update method
     if ((this.id == 1) || (this.id == 5)) {


### PR DESCRIPTION
Closes #71
Closes #117

The shaking when hovering between emojis occurs due to changes in the width of the label text. This is more obvious for categories with gender and/or skin tone modifier options where the label text shares its row with the modifer buttons.

A quick fix is to set the text label to occupy a fixed `width: `. I used  `emojisize` and `this._nbColumns` to estimate a safe width limit.

The appended `...` string can be dropped since JS automatically truncates text exceeding `width: ` with a `...`.

---

It is kind of hacky, it seems fine when I set different zoom levels on my GNOME Desktop. A more stable solution is to put the label text on its own row separate from the gender/skin tone buttons row, and use the max width of all the other rows in the popup menu to calculate its fixed `width: ` property.
