### PR TITLE
fix: disconnect skin-tone/gender handlers to avoid SIGSEGV on disposed St.Entry

### DIFF
--- a/emoji-copy@felipeftn/emojiSearchItem.js
+++ b/emoji-copy@felipeftn/emojiSearchItem.js
@@ -30,14 +30,15 @@ export class EmojiSearchItem {
       this._onSearchTextChanged.bind(this),
     );
 
-    // Listen for skin tone changes and refresh search results
+    // Listen for skin tone changes and refresh search results. Keep the
+    // handler ids so destroy() can disconnect them: _settings outlives this
+    // item, and firing on a disposed searchEntry segfaults the shell.
+    this._settingsHandlerIds = [];
     if (this._settings && this._settings.connect) {
-      this._settings.connect('changed::skin-tone', () => {
-        this._onSearchTextChanged();
-      });
-      this._settings.connect('changed::gender', () => {
-        this._onSearchTextChanged();
-      });
+      this._settingsHandlerIds.push(
+        this._settings.connect('changed::skin-tone', () => this._onSearchTextChanged()),
+        this._settings.connect('changed::gender', () => this._onSearchTextChanged()),
+      );
     }
 
     this.super_item.add_child(this.searchEntry);
@@ -109,8 +110,8 @@ export class EmojiSearchItem {
   // Updates the "recently used" buttons content in reaction to a new search
   // query (the text changed or the category changed).
   _onSearchTextChanged() {
-    let searchedText = this.searchEntry.get_text();
-    if (searchedText === "") {
+    let searchedText = this.searchEntry?.get_text();
+    if (searchedText === null || searchedText === undefined || searchedText === "") {
       this._buildRecents();
       this._updateSensitivity();
       return;
@@ -230,5 +231,15 @@ export class EmojiSearchItem {
     this._buildRecents();
     this.saveRecents();
     this.emojiCopy._onSearchTextChanged();
+  }
+
+  destroy() {
+    if (this._settings && this._settingsHandlerIds) {
+      for (const id of this._settingsHandlerIds) {
+        this._settings.disconnect(id);
+      }
+    }
+    this._settingsHandlerIds = [];
+    this.super_item?.destroy();
   }
 }

--- a/emoji-copy@felipeftn/extension.js
+++ b/emoji-copy@felipeftn/extension.js
@@ -141,6 +141,7 @@ export default class EmojiCopy extends Extension {
     this._settings.disconnect(this.signaux[0]);
     this._settings.disconnect(this.signaux[1]);
     this._settings.disconnect(this.signaux[2]);
+    this._settings.disconnect(this.signaux[3]);
 
     if (this.timeoutSourceId) {
       GLib.Source.remove(this.timeoutSourceId);
@@ -148,6 +149,7 @@ export default class EmojiCopy extends Extension {
     }
 
     this.sqlite.destroy();
+    this.searchItem.destroy();
     this.super_btn.destroy();
     this.searchItem = null;
     this._settings = null;
@@ -173,6 +175,7 @@ export default class EmojiCopy extends Extension {
       c.setNbCols(nbCols);
     });
 
+    this.searchItem?.destroy();
     this.searchItem = new EmojiSearchItem(this, nbCols);
   }
 


### PR DESCRIPTION
Fixes #145.

## Problem

`EmojiSearchItem` connects `changed::skin-tone` and `changed::gender` handlers on the long-lived `Gio.Settings` object but never stores their ids and never disconnects them. There is no `destroy()` on the class, and both `updateNbCols()` and `disable()` drop a `searchItem` (the latter also disposes its `St.Entry` via `super_btn.destroy()`) without disconnecting those handlers.

Because GNOME shares the `Gio.Settings` backend per schema, any later write to `skin-tone`/`gender` (e.g. clicking a tone button) fires the orphaned handler on a stale item, which calls `this.searchEntry.get_text()` on a disposed `St.Entry`:

```
Object St.Entry has been already disposed
clutter_text_get_text: assertion 'CLUTTER_IS_TEXT (self)' failed
GNOME Shell crashed with signal 11
```

Native backtrace (apport core dump) confirms the fatal frame is `clutter_text_get_text()` in `libmutter-clutter-18`, reached from GJS via libffi. In practice it triggers after any lock/unlock or suspend/resume (which runs a `disable → enable` cycle) followed by a skin-tone/gender click, taking down the whole session. Introduced by #126 (v33), still present in v34.

## Fix

- `emojiSearchItem.js`: store the settings handler ids (`_settingsHandlerIds`) and add a `destroy()` that disconnects them and destroys `super_item`. Make `_onSearchTextChanged()` defensive against a null/disposed entry (`searchEntry?.get_text()`).
- `extension.js`: call `searchItem.destroy()` before replacing it in `updateNbCols()` and in `disable()`. Also disconnect `signaux[3]` (`changed::nbcols`), which was leaked.

## Testing

Patched files validated with `node --check`. Applied locally and reloaded the extension; clicking skin-tone/gender buttons after lock/unlock cycles no longer crashes the shell.
