### PR TITLE
Paste without copying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# Ignore dot files
+.*
+!.github/
+!.eslint*
+!.gitignore
+!.gitattributes
+
 # Ignore node files
 node_modules/
 package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ all: clean build
 build: $(SCHEMA_COMPILED_FILE) $(EMOJIS_DB) $(ZIP_NAME)
 	@echo "[+] EMOJI COPY BUILT"
 
-install: build
+install: clean build
 	gnome-extensions install $(ZIP_NAME) --force
 	@echo "Extension installed successfully! Now restart the Shell ('Alt'+'F2', then 'restart')."
 

--- a/emoji-copy@felipeftn/emojiButton.js
+++ b/emoji-copy@felipeftn/emojiButton.js
@@ -191,21 +191,53 @@ export class EmojiButton {
     return Clutter.EVENT_PROPAGATE;
   }
 
-  replaceClipboardAndClose(emojiToCopy) {
-    this.clipboard.set_text(
-      CLIPBOARD_TYPE,
-      emojiToCopy,
-    );
-    this.clipboard.set_text(
-      PRIMARY_CLIPBOARD_TYPE,
-      emojiToCopy,
-    );
-    this.emojiCopy.get_super_btn().menu.close();
-
+  _getPasteMode() {
+    // Read the new string setting with fallback to the old boolean key
+    const newMode = this._settings.get_string("paste-mode");
+    if (newMode === "paste-on-select" || newMode === "paste-no-clip") {
+      return newMode;
+    }
+    // Default ("copy-only") or unknown value — check old boolean fallback
     if (this._settings.get_boolean("paste-on-select")) {
-      this.triggerPasteHack();
+      return "paste-on-select";
+    }
+    return "copy-only";
+  }
+
+  replaceClipboardAndClose(emojiToCopy) {
+    const mode = this._getPasteMode();
+
+    if (mode === "paste-no-clip") {
+      // Save clipboard, copy emoji momentarily, paste, then restore
+      this.clipboard.get_text(CLIPBOARD_TYPE, (_, savedText) => {
+        this.clipboard.set_text(CLIPBOARD_TYPE, emojiToCopy);
+        this.clipboard.set_text(PRIMARY_CLIPBOARD_TYPE, emojiToCopy);
+        this.triggerPasteHack();
+        // Restore the original clipboard contents after paste has been triggered
+        GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50, () => {
+          this.clipboard.set_text(CLIPBOARD_TYPE, savedText || '');
+          this.clipboard.set_text(PRIMARY_CLIPBOARD_TYPE, savedText || '');
+          return GLib.SOURCE_REMOVE;
+        });
+      });
+    } else {
+      // Copy to clipboard (always happens for "copy-only" and "paste-on-select")
+      this.clipboard.set_text(
+        CLIPBOARD_TYPE,
+        emojiToCopy,
+      );
+      this.clipboard.set_text(
+        PRIMARY_CLIPBOARD_TYPE,
+        emojiToCopy,
+      );
+
+      if (mode === "paste-on-select") {
+        // skipped in "copy-only" mode: just copies, no paste
+        this.triggerPasteHack();
+      }
     }
 
+    this.emojiCopy.get_super_btn().menu.close();
     return Clutter.EVENT_STOP;
   }
 

--- a/emoji-copy@felipeftn/prefs.js
+++ b/emoji-copy@felipeftn/prefs.js
@@ -40,12 +40,37 @@ export default class EmojiCopyPrefs extends ExtensionPreferences {
         });
         general_gp.add(show_indicator);
 
-        // Emoji copy paste on Select Switch
-        const paste_on_select = new Adw.SwitchRow({
-            title: _('Paste on Select'),
-            subtitle: _('Automatically paste the selected emoji.'),
+        // Paste mode selector (copy-only, paste-on-select, paste-no-clip)
+        const PASTE_MODES = ['copy-only', 'paste-on-select', 'paste-no-clip'];
+        const PASTE_LABELS = [
+            _('Copy only'),
+            _('Paste on select'),
+            _('Paste without copying'),
+        ];
+        const paste_mode_list = Gtk.StringList.new(PASTE_LABELS);
+
+        // Determine the effective mode (new key with fallback to old boolean)
+        const rawMode = this._window._settings.get_string('paste-mode');
+        let effectiveIndex = PASTE_MODES.indexOf(rawMode);
+        if (effectiveIndex === -1) {
+            // Fallback: old boolean key
+            effectiveIndex = this._window._settings.get_boolean('paste-on-select') ? 1 : 0;
+        }
+
+        const paste_mode = new Adw.ComboRow({
+            title: _('Paste Mode'),
+            subtitle: _('Behavior when selecting an emoji in the menu.'),
+            model: paste_mode_list,
+            selected: effectiveIndex,
         });
-        general_gp.add(paste_on_select);
+        general_gp.add(paste_mode);
+
+        paste_mode.connect('notify::selected', () => {
+            const idx = paste_mode.get_selected();
+            if (idx >= 0 && idx < PASTE_MODES.length) {
+                this._window._settings.set_string('paste-mode', PASTE_MODES[idx]);
+            }
+        });
 
         // Keybind active (true or false)
         const active_keybind = new Adw.SwitchRow({
@@ -92,7 +117,6 @@ export default class EmojiCopyPrefs extends ExtensionPreferences {
 
         // Bind Adwaita field values to schema
         this._window._settings.bind('always-show', show_indicator, 'active', Gio.SettingsBindFlags.DEFAULT);
-        this._window._settings.bind('paste-on-select', paste_on_select, 'active', Gio.SettingsBindFlags.DEFAULT);
         this._window._settings.bind('active-keybind', active_keybind, 'active', Gio.SettingsBindFlags.DEFAULT);
     }
 

--- a/emoji-copy@felipeftn/schemas/org.gnome.shell.extensions.emoji-copy.gschema.xml
+++ b/emoji-copy@felipeftn/schemas/org.gnome.shell.extensions.emoji-copy.gschema.xml
@@ -30,6 +30,11 @@
       <summary>if paste on select is enabled</summary>
       <description>if true, Selecting an emoji will attempt to paste it on the focused textfield</description>
     </key>
+    <key type="s" name="paste-mode">
+      <default>'copy-only'</default>
+      <summary>behavior when selecting an emoji</summary>
+      <description>Possible values: 'copy-only' (copy to clipboard), 'paste-on-select' (copy then paste), 'paste-no-clip' (paste without keeping in clipboard).</description>
+    </key>
     <key type="b" name="active-keybind">
       <default>true</default>
       <summary>if keybinding is enabled</summary>


### PR DESCRIPTION
trying to implement #30 and taking into account #29

my attempted approach of trying to restore the clipboard after pasting doesn't work - it just doesn't paste at all, I can't figure it out. maybe this was not a "good first issue" after all. 🙈

I have no more energy for this, just leaving it here if someone else wants to attempt it.

I spent hours just trying to make the extension install and reload - `make install` does run `build`, but just keeps installing the old version?? only `clean build` actually builds and installs the updated version.

I honestly don't know how anybody gets anything done with the dreadful dev workflow that GTK offers, wtf man 🥲
