### PR TITLE
feat: added the ability to make the window appear next to the cursor …

### DIFF
--- a/emoji-copy@felipeftn/extension.js
+++ b/emoji-copy@felipeftn/extension.js
@@ -71,6 +71,14 @@ export default class EmojiCopy extends Extension {
       "right",
     );
 
+    this._cursorAnchor = new St.Widget({
+      width: 1,
+      height: 1,
+      opacity: 0,
+      reactive: false,
+    });
+    Main.uiGroup.add_child(this._cursorAnchor);
+
     this.super_btn.menu.connect(
       "open-state-changed",
       this._onOpenStateChanged.bind(this),
@@ -138,6 +146,12 @@ export default class EmojiCopy extends Extension {
       Main.wm.removeKeybinding("emoji-keybind");
     }
 
+    if (this._cursorAnchor) {
+      Main.uiGroup.remove_child(this._cursorAnchor);
+      this._cursorAnchor.destroy();
+      this._cursorAnchor = null;
+    }
+
     this._settings.disconnect(this.signaux[0]);
     this._settings.disconnect(this.signaux[1]);
     this._settings.disconnect(this.signaux[2]);
@@ -162,6 +176,41 @@ export default class EmojiCopy extends Extension {
 
   disconnectSignals() {}
 
+  toggleMenu() {
+    const windowLocation = this._settings.get_string("window-location");
+
+    if (this.super_btn.menu.isOpen) {
+      this.super_btn.menu.close();
+      return;
+    }
+
+    if (!this._cursorAnchor) {
+      this._cursorAnchor = new St.Widget({
+        width: 1,
+        height: 1,
+        opacity: 0,
+        reactive: false,
+      });
+      Main.uiGroup.add_child(this._cursorAnchor);
+    }
+
+    if (windowLocation === "cursor") {
+      let x, y;
+      [x, y] = global.get_pointer();
+
+      const margin = 10;
+      const clampedX = Math.max(margin, Math.min(x, global.stage.width - margin));
+      const clampedY = Math.max(margin, Math.min(y, global.stage.height - margin));
+
+      this._cursorAnchor.set_position(clampedX, clampedY);
+      this.super_btn.menu.sourceActor = this._cursorAnchor;
+    } else {
+      this.super_btn.menu.sourceActor = this.super_btn;
+    }
+
+    this.super_btn.menu.open(true);
+  }
+
   updateStyle() {
     this.searchItem.updateStyleRecents();
     this.emojiCategories.forEach(function (c) {
@@ -177,10 +226,6 @@ export default class EmojiCopy extends Extension {
 
     this.searchItem?.destroy();
     this.searchItem = new EmojiSearchItem(this, nbCols);
-  }
-
-  toggle() {
-    this.super_btn.menu.toggle();
   }
 
   _onOpenStateChanged(_, open) {
@@ -284,7 +329,7 @@ export default class EmojiCopy extends Extension {
       this._settings,
       Meta.KeyBindingFlags.NONE,
       Shell.ActionMode.ALL,
-      this.toggle.bind(this),
+      this.toggleMenu.bind(this),
     );
   }
 

--- a/emoji-copy@felipeftn/prefs.js
+++ b/emoji-copy@felipeftn/prefs.js
@@ -40,6 +40,29 @@ export default class EmojiCopyPrefs extends ExtensionPreferences {
         });
         general_gp.add(show_indicator);
 
+        // Show emoji copy window next to cursor (true or false)
+        const location_options = ['top-bar', 'cursor'];
+        const window_location = new Adw.ComboRow({
+            title: _('Window Location'),
+            subtitle: _('Where to display the emoji menu window.'),
+            model: Gtk.StringList.new([
+                _('Top bar'),
+                _('Cursor'),
+            ]),
+        });
+        general_gp.add(window_location);
+
+        const current_location = this._window._settings.get_string('window-location');
+        const initial_index = location_options.indexOf(current_location);
+        window_location.set_selected(initial_index !== -1 ? initial_index : 0);
+
+        window_location.connect('notify::selected', () => {
+            const index = window_location.get_selected();
+            if (index >= 0 && index < location_options.length) {
+                this._window._settings.set_string('window-location', location_options[index]);
+            }
+        });
+
         // Emoji copy paste on Select Switch
         const paste_on_select = new Adw.SwitchRow({
             title: _('Paste on Select'),

--- a/emoji-copy@felipeftn/schemas/org.gnome.shell.extensions.emoji-copy.gschema.xml
+++ b/emoji-copy@felipeftn/schemas/org.gnome.shell.extensions.emoji-copy.gschema.xml
@@ -25,6 +25,15 @@
       <summary>default memorized emojis</summary>
       <description></description>
     </key>
+    <key name="window-location" type="s">
+      <choices>
+        <choice value="top-bar"/>
+        <choice value="cursor"/>
+      </choices>
+      <default>'top-bar'</default>
+      <summary>Window location mode</summary>
+      <description>Where to display the emoji window: 'Top bar', 'Cursor'.</description>
+    </key>
     <key type="b" name="paste-on-select">
       <default>true</default>
       <summary>if paste on select is enabled</summary>


### PR DESCRIPTION
Added a new setting called "Window location", it has two modes:
- Top bar [Default]: when keybind is pressed, make the window appear in GNOME's topbar
- Cursor: when keybind is pressed, make the window appear next to the cursor

Issue: #133 