### PR TITLE
feat: keep open on select

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Please feel free to use and contribute to this project. 😃
 - skin tone & gender modifiers
 - middle-click to set to the clipboard without closing the menu (or <kbd>Ctrl</kbd>+<kbd>Enter</kbd>)
 - right-click to add the emoji at the end of the current clipboard content (or <kbd>Shift</kbd>+<kbd>Enter</kbd>)
+- "Keep Open on Select" preference to keep the menu open after selecting an emoji, so you can pick several in a row
+- "Paste on Select" preference to automatically paste the selected emoji into the focused text field
 
 Keyboard navigation is designed to work **with <kbd>Tab</kbd>, not the arrows**.
 

--- a/emoji-copy@felipeftn/emojiButton.js
+++ b/emoji-copy@felipeftn/emojiButton.js
@@ -191,16 +191,19 @@ export class EmojiButton {
     return Clutter.EVENT_PROPAGATE;
   }
 
+  _setClipboards(text) {
+    this.clipboard.set_text(CLIPBOARD_TYPE, text);
+    this.clipboard.set_text(PRIMARY_CLIPBOARD_TYPE, text);
+  }
+
   replaceClipboardAndClose(emojiToCopy) {
-    this.clipboard.set_text(
-      CLIPBOARD_TYPE,
-      emojiToCopy,
-    );
-    this.clipboard.set_text(
-      PRIMARY_CLIPBOARD_TYPE,
-      emojiToCopy,
-    );
-    this.emojiCopy.get_super_btn().menu.close();
+    this._setClipboards(emojiToCopy);
+
+    // The "keep-open" setting turns the default action into a "stay" one,
+    // so several emojis can be picked in a row.
+    if (!this._settings.get_boolean("keep-open")) {
+      this.emojiCopy.get_super_btn().menu.close();
+    }
 
     if (this._settings.get_boolean("paste-on-select")) {
       this.triggerPasteHack();
@@ -210,28 +213,14 @@ export class EmojiButton {
   }
 
   replaceClipboardAndStay(emojiToCopy) {
-    this.clipboard.set_text(
-      CLIPBOARD_TYPE,
-      emojiToCopy,
-    );
-    this.clipboard.set_text(
-      PRIMARY_CLIPBOARD_TYPE,
-      emojiToCopy,
-    );
+    this._setClipboards(emojiToCopy);
 
     return Clutter.EVENT_STOP;
   }
 
   addToClipboardAndStay(emojiToCopy) {
     this.clipboard.get_text(CLIPBOARD_TYPE, (_, text) => {
-      this.clipboard.set_text(
-        CLIPBOARD_TYPE,
-        text + emojiToCopy,
-      );
-      this.clipboard.set_text(
-        PRIMARY_CLIPBOARD_TYPE,
-        text + emojiToCopy,
-      );
+      this._setClipboards(text + emojiToCopy);
     });
 
     return Clutter.EVENT_STOP;

--- a/emoji-copy@felipeftn/emojiButton.js
+++ b/emoji-copy@felipeftn/emojiButton.js
@@ -220,7 +220,8 @@ export class EmojiButton {
 
   addToClipboardAndStay(emojiToCopy) {
     this.clipboard.get_text(CLIPBOARD_TYPE, (_, text) => {
-      this._setClipboards(text + emojiToCopy);
+      // text is null when the clipboard is empty (e.g. a fresh session)
+      this._setClipboards((text ?? "") + emojiToCopy);
     });
 
     return Clutter.EVENT_STOP;

--- a/emoji-copy@felipeftn/emojiButton.js
+++ b/emoji-copy@felipeftn/emojiButton.js
@@ -194,6 +194,9 @@ export class EmojiButton {
   _setClipboards(text) {
     this.clipboard.set_text(CLIPBOARD_TYPE, text);
     this.clipboard.set_text(PRIMARY_CLIPBOARD_TYPE, text);
+    // From now on the clipboard only holds emojis picked in this menu
+    // session, so further "append" selections may append to it.
+    this.emojiCopy.clipboardOwned = true;
   }
 
   replaceClipboardAndClose(emojiToCopy) {
@@ -219,6 +222,13 @@ export class EmojiButton {
   }
 
   addToClipboardAndStay(emojiToCopy) {
+    // Content copied before the menu was opened is not ours to append to:
+    // the first selection replaces it, the following ones append.
+    if (!this.emojiCopy.clipboardOwned) {
+      this._setClipboards(emojiToCopy);
+      return Clutter.EVENT_STOP;
+    }
+
     this.clipboard.get_text(CLIPBOARD_TYPE, (_, text) => {
       // text is null when the clipboard is empty (e.g. a fresh session)
       this._setClipboards((text ?? "") + emojiToCopy);

--- a/emoji-copy@felipeftn/extension.js
+++ b/emoji-copy@felipeftn/extension.js
@@ -229,6 +229,11 @@ export default class EmojiCopy extends Extension {
   }
 
   _onOpenStateChanged(_, open) {
+    if (open) {
+      // The clipboard still holds whatever was copied before opening the
+      // menu; the first "append" selection must not append to it.
+      this.clipboardOwned = false;
+    }
     this.super_btn.visible = open || this._settings.get_boolean("always-show");
     this.clearCategories();
     this.searchItem.searchEntry.set_text("");

--- a/emoji-copy@felipeftn/prefs.js
+++ b/emoji-copy@felipeftn/prefs.js
@@ -70,6 +70,13 @@ export default class EmojiCopyPrefs extends ExtensionPreferences {
         });
         general_gp.add(paste_on_select);
 
+        // Keep the emoji menu open after selecting an emoji
+        const keep_open = new Adw.SwitchRow({
+            title: _('Keep Open on Select'),
+            subtitle: _('Keep the emoji menu open after selecting an emoji.'),
+        });
+        general_gp.add(keep_open);
+
         // Keybind active (true or false)
         const active_keybind = new Adw.SwitchRow({
             title: _('Use Keybind'),
@@ -116,6 +123,7 @@ export default class EmojiCopyPrefs extends ExtensionPreferences {
         // Bind Adwaita field values to schema
         this._window._settings.bind('always-show', show_indicator, 'active', Gio.SettingsBindFlags.DEFAULT);
         this._window._settings.bind('paste-on-select', paste_on_select, 'active', Gio.SettingsBindFlags.DEFAULT);
+        this._window._settings.bind('keep-open', keep_open, 'active', Gio.SettingsBindFlags.DEFAULT);
         this._window._settings.bind('active-keybind', active_keybind, 'active', Gio.SettingsBindFlags.DEFAULT);
     }
 

--- a/emoji-copy@felipeftn/prefs.js
+++ b/emoji-copy@felipeftn/prefs.js
@@ -18,6 +18,27 @@ export default class EmojiCopyPrefs extends ExtensionPreferences {
         this._general();
     }
 
+    _shortcuts(page) {
+        const shortcuts_gp = new Adw.PreferencesGroup({
+            title: _('Shortcuts'),
+            description: _('Ways to pick an emoji from the menu'),
+        });
+        page.add(shortcuts_gp);
+
+        const shortcuts = [
+            [_('Left-click / Enter'), _('Copy the emoji and close the menu')],
+            [_('Middle-click / Ctrl+Enter'), _('Copy the emoji without closing the menu')],
+            [_('Right-click / Shift+Enter'), _('Add the emoji to the end of the clipboard content')],
+            [_('Tab'), _('Navigate between emojis')],
+        ];
+        for (const [keys, description] of shortcuts) {
+            shortcuts_gp.add(new Adw.ActionRow({
+                title: keys,
+                subtitle: description,
+            }));
+        }
+    }
+
     _general() {
         // General page
         const general_pg = new Adw.PreferencesPage({
@@ -125,6 +146,9 @@ export default class EmojiCopyPrefs extends ExtensionPreferences {
         this._window._settings.bind('paste-on-select', paste_on_select, 'active', Gio.SettingsBindFlags.DEFAULT);
         this._window._settings.bind('keep-open', keep_open, 'active', Gio.SettingsBindFlags.DEFAULT);
         this._window._settings.bind('active-keybind', active_keybind, 'active', Gio.SettingsBindFlags.DEFAULT);
+
+        // Mouse and keyboard shortcuts reference
+        this._shortcuts(general_pg);
     }
 
     _openAboutPage() {

--- a/emoji-copy@felipeftn/schemas/org.gnome.shell.extensions.emoji-copy.gschema.xml
+++ b/emoji-copy@felipeftn/schemas/org.gnome.shell.extensions.emoji-copy.gschema.xml
@@ -39,6 +39,11 @@
       <summary>if paste on select is enabled</summary>
       <description>if true, Selecting an emoji will attempt to paste it on the focused textfield</description>
     </key>
+    <key type="b" name="keep-open">
+      <default>false</default>
+      <summary>if the menu stays open after selecting an emoji</summary>
+      <description>if true, the emoji menu will stay open after selecting an emoji, allowing to pick several emojis in a row.</description>
+    </key>
     <key type="b" name="active-keybind">
       <default>true</default>
       <summary>if keybinding is enabled</summary>


### PR DESCRIPTION
## This feature was asked in #137. Now it's done! :tada:

It was added as a new preference, that keeps the menu open after selecting an emoji.
This feature is enabled by right clicking  and it's described in the configuration panel.

- [x] Stress tests before merging

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/2d00c140-0487-4724-ada2-0462daaf3ba9" />

